### PR TITLE
fix provider to reference region

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -10,7 +10,7 @@ terraform {
 
 # Configure the IBM Provider
 provider "ibm" {
-  region           = "us-south"
+  region           = var.region
   ibmcloud_api_key = var.ibmcloud_api_key
   generation       = 2
 


### PR DESCRIPTION
Bug Found in QA:
Provider region was static, fixed that. Deployment in new regions has been tested and works.


